### PR TITLE
Send guest profile type when using guest checkout

### DIFF
--- a/Gateway/Request/CustomerDataBuilder.php
+++ b/Gateway/Request/CustomerDataBuilder.php
@@ -80,10 +80,14 @@ class CustomerDataBuilder implements BuilderInterface
 
         $customerId = null;
         $profileId = null;
+        $guest = false;
 
         if ($this->session->isLoggedIn()) {
             $customerId = $this->session->getCustomerId();
             $profileId = $this->getCimProfileId();
+        } else {
+            $email = null;
+            $guest = true;
         }
 
         /**
@@ -92,6 +96,7 @@ class CustomerDataBuilder implements BuilderInterface
         $customerProfile = $this->customerProfileFactory->create();
         $customerProfile->setCustomerId($customerId);
         $customerProfile->setEmail($email ?: $order->getOrderIncrementId() . '_' . mt_rand() . '-' . time());
+        $customerProfile->setProfileType($guest ? 'guest' : 'regular');
 
         return [
             self::CUSTOMER_ID => $customerId,

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   ],
   "require": {
     "magento/framework": "~101.0.0",
-    "pmclain/authorizenet-php-sdk": "~0.1.5"
+    "pmclain/authorizenet-php-sdk": "~0.1.7"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
Solves issue where guest with same email address comes back and reorders. First order works but second order will fail with error message in https://github.com/pmclain/module-authorizenetcim/issues/26

Depends on 
https://github.com/pmclain/authorizenet-php-sdk/pull/4

Possible other fixes
- https://github.com/pmclain/module-authorizenetcim/issues/26

